### PR TITLE
Q module is actually q

### DIFF
--- a/lib/box/box_client.js
+++ b/lib/box/box_client.js
@@ -1,4 +1,4 @@
-var Q = require('Q')
+var Q = require('q')
     , request = require('request')
     , winston = require('winston')
     , errorTypes = require('../errors.js')

--- a/lib/box/box_provider.js
+++ b/lib/box/box_provider.js
@@ -1,4 +1,4 @@
-var Q = require('Q')
+var Q = require('q')
     , OAuth = require('OAuth')
     , winston = require('winston');
 

--- a/lib/dropbox/dropbox_client.js
+++ b/lib/dropbox/dropbox_client.js
@@ -1,4 +1,4 @@
-var Q = require('Q')
+var Q = require('q')
     , request = require('request')
     , Dropbox = require("dropbox")
     , winston = require('winston')

--- a/lib/dropbox/dropbox_provider.js
+++ b/lib/dropbox/dropbox_provider.js
@@ -1,4 +1,4 @@
-var Q = require('Q')
+var Q = require('q')
     , OAuth = require('OAuth')
     , winston = require('winston');
 

--- a/lib/google_drive/google_drive_client.js
+++ b/lib/google_drive/google_drive_client.js
@@ -1,4 +1,4 @@
-var Q = require('Q')
+var Q = require('q')
     , request = require('request')
     , googleapis = require('googleapis')
     , winston = require('winston');

--- a/lib/google_drive/google_drive_provider.js
+++ b/lib/google_drive/google_drive_provider.js
@@ -1,5 +1,5 @@
 var googleapis = require('googleapis')
-    , Q = require('Q')
+    , Q = require('q')
     , winston = require('winston')
 
 exports.provider = function (provider_options) {

--- a/lib/skydrive/skydrive_client.js
+++ b/lib/skydrive/skydrive_client.js
@@ -1,4 +1,4 @@
-var Q = require('Q')
+var Q = require('q')
     , request = require('request')
     , winston = require('winston')
     , errorTypes = require('../errors.js')

--- a/lib/skydrive/skydrive_provider.js
+++ b/lib/skydrive/skydrive_provider.js
@@ -1,4 +1,4 @@
-var Q = require('Q')
+var Q = require('q')
     , OAuth = require('OAuth')
     , winston = require('winston');
 


### PR DESCRIPTION
Case sensitive platforms (linux) need the Q module to be required as
“require(‘q’)” not “require(‘Q’)” (because that's the name on npm - https://www.npmjs.org/package/q)

Heroku, for example, will fail
